### PR TITLE
feat(env): adiciona validação de variáveis de ambiente com Zod

### DIFF
--- a/backend/src/Datenbank/configdb.ts
+++ b/backend/src/Datenbank/configdb.ts
@@ -4,7 +4,7 @@ import { env } from '../env'
 
 export async function openDb() {
 	return open({
-		filename: String(env.PATH_TO_DB),
+		filename: env.PATH_TO_DB,
 		driver: Database,
 	})
 }

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,7 +1,17 @@
 import 'dotenv/config'
+import { z } from 'zod'
 
-export const env = {
-	NODE_ENV: process.env.NODE_ENV,
-	PORT: process.env.PORT,
-	PATH_TO_DB: process.env.PATH_TO_DB,
+const envSchema = z.object({
+	NODE_ENV: z.enum(['development', 'production']),
+	PORT: z.coerce.number().default(3000),
+	PATH_TO_DB: z.string(),
+})
+
+const { success, data, error } = envSchema.safeParse(process.env)
+
+if (!success) {
+	console.error('Invalid environment variables:', error.format())
+	throw new Error('Invalid environment variables')
 }
+
+export const env = data

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,7 +1,7 @@
 import { app } from './app'
 import { env } from './env'
 
-app.listen(Number(env.PORT), (err) => {
+app.listen(env.PORT, (err) => {
 	if (err) {
 		console.error(err)
 	}


### PR DESCRIPTION
- Substitui a exportação direta de variáveis de ambiente por validação usando Zod.
- Adiciona suporte para valores padrão e validação de tipos.
- Lança erro em caso de variáveis inválidas.
- Remove conversão explícita de porta para número
- Utiliza a validação de tipo do Zod para garantir que a porta seja um número.
- Remove conversão explícita de PATH_TO_DB para string
- Utiliza a validação de tipo do Zod para garantir que o caminho do banco seja uma string.