### PR TITLE
feat(useCase): alterar retorno do método create e implementar caso de uso

### DIFF
--- a/backend/src/entities/Reserva.ts
+++ b/backend/src/entities/Reserva.ts
@@ -5,7 +5,7 @@
  * (uma regra que garante integridade da entidade Reserva)
  */
 
-type StatusReserva = 'aguardando' | 'confirmada' | 'cancelada'
+export type StatusReserva = 'aguardando' | 'confirmada' | 'cancelada'
 
 interface ReservaRequest {
 	id: string

--- a/backend/src/repositories/ReservaRepository.ts
+++ b/backend/src/repositories/ReservaRepository.ts
@@ -1,6 +1,6 @@
 import type { Reserva } from '../entities/Reserva'
 
 export interface ReservaRepository {
-	create(reserva: Reserva): Promise<void>
+	create(reserva: Reserva): Promise<Reserva>
 	findByMesaId(mesaId: string): Promise<Reserva | null>
 }

--- a/backend/src/repositories/sqlite/SqliteReservaRepository.ts
+++ b/backend/src/repositories/sqlite/SqliteReservaRepository.ts
@@ -12,19 +12,28 @@ export class SqliteReservaRepository implements ReservaRepository {
 			}
 		})
 	}
-	async create(reserva: Reserva): Promise<void> {
-		this.db.run(
-			'INSERT INTO reservas (id, mesaId, nomeResponsavel, data, hora, quantidadePessoas, status) VALUES (?, ?, ?, ?, ?, ?, ?)',
-			[
-				reserva.id,
-				reserva.mesaId,
-				reserva.nomeResponsavel,
-				reserva.data,
-				reserva.hora,
-				reserva.quantidadePessoas,
-				reserva.status,
-			],
-		)
+	async create(reserva: Reserva): Promise<Reserva> {
+		return new Promise((resolve, reject) => {
+			this.db.run(
+				'INSERT INTO reservas (id, mesaId, nomeResponsavel, data, hora, quantidadePessoas, status) VALUES (?, ?, ?, ?, ?, ?, ?)',
+				[
+					reserva.id,
+					reserva.mesaId,
+					reserva.nomeResponsavel,
+					reserva.data,
+					reserva.hora,
+					reserva.quantidadePessoas,
+					reserva.status,
+				],
+				(result: Reserva, err: Error | null) => {
+					if (err) {
+						reject(new Error(`Erro ao criar reserva: ${err.message}`))
+					} else {
+						resolve(result)
+					}
+				},
+			)
+		})
 	}
 
 	async findByMesaId(mesaId: string): Promise<Reserva | null> {

--- a/backend/src/useCases/CriarReservaUseCase.ts
+++ b/backend/src/useCases/CriarReservaUseCase.ts
@@ -1,0 +1,54 @@
+import { Reserva } from '../entities/Reserva'
+import type { ReservaRepository } from '../repositories/ReservaRepository'
+import type { StatusReserva } from '../entities/Reserva'
+import { randomUUID } from 'node:crypto'
+
+interface CriarReservaRequest {
+	mesaId: string
+	nomeResponsavel: string
+	data: Date
+	hora: Date
+	quantidadePessoas: number
+	status?: StatusReserva
+}
+
+interface CriarReservaResponse {
+	reserva: Reserva
+}
+
+export class CriarReservaUseCase {
+	private reservaRepository: ReservaRepository
+
+	constructor(reservaRepository: ReservaRepository) {
+		this.reservaRepository = reservaRepository
+	}
+
+	async execute({
+		mesaId,
+		nomeResponsavel,
+		data,
+		hora,
+		quantidadePessoas,
+		status,
+	}: CriarReservaRequest): Promise<CriarReservaResponse> {
+		const reservaExistente = await this.reservaRepository.findByMesaId(mesaId)
+
+		if (reservaExistente) {
+			throw new Error('Já existe uma reserva para esta mesa')
+		}
+		const reserva = await this.reservaRepository.create(
+			new Reserva({
+				id: randomUUID(),
+				mesaId,
+				nomeResponsavel,
+				data,
+				hora,
+				quantidadePessoas,
+				status,
+			}),
+		)
+		return {
+			reserva,
+		}
+	}
+}

--- a/backend/src/useCases/factories/makeCriarReservaUseCase.ts
+++ b/backend/src/useCases/factories/makeCriarReservaUseCase.ts
@@ -1,0 +1,8 @@
+import { SqliteReservaRepository } from '../../repositories/sqlite/SqliteReservaRepository'
+import { CriarReservaUseCase } from '../CriarReservaUseCase'
+
+export const makeCriarReservaUseCase = (): CriarReservaUseCase => {
+	const reservaRepository = new SqliteReservaRepository()
+	const criarReservaUseCase = new CriarReservaUseCase(reservaRepository)
+	return criarReservaUseCase
+}


### PR DESCRIPTION
- O método create do ReservaRepository agora retorna a entidade Reserva criada.
- Atualização da implementação SqliteReservaRepository para refletir a nova assinatura e retornar a reserva criada.
- Criação do caso de uso CriarReservaUseCase para encapsular a lógica de criação de reservas, incluindo verificação de reserva existente para a mesa.
- Adição da factory makeCriarReservaUseCase para facilitar a criação do caso de uso com o repositório apropriado.
- Exportação do tipo StatusReserva em Reserva.ts.